### PR TITLE
fix pointer type linked docs

### DIFF
--- a/pointers.go
+++ b/pointers.go
@@ -3,7 +3,7 @@ package jsony
 // PBool is a pointer version of [Bool].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PBool].
+// Otherwise, behaves exactly as [Bool].
 func PBool(v *bool) Encoder {
 	if v == nil {
 		return Null
@@ -14,7 +14,7 @@ func PBool(v *bool) Encoder {
 // PInt is a pointer version of [Int].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PInt].
+// Otherwise, behaves exactly as [Int].
 func PInt(v *int) Encoder {
 	if v == nil {
 		return Null
@@ -25,7 +25,7 @@ func PInt(v *int) Encoder {
 // PInt8 is a pointer version of [Int8].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PInt8].
+// Otherwise, behaves exactly as [Int8].
 func PInt8(v *int8) Encoder {
 	if v == nil {
 		return Null
@@ -36,7 +36,7 @@ func PInt8(v *int8) Encoder {
 // PInt16 is a pointer version of [Int16].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PInt16].
+// Otherwise, behaves exactly as [Int16].
 func PInt16(v *int16) Encoder {
 	if v == nil {
 		return Null
@@ -47,7 +47,7 @@ func PInt16(v *int16) Encoder {
 // PInt32 is a pointer version of [Int32].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PInt32].
+// Otherwise, behaves exactly as [Int32].
 func PInt32(v *int32) Encoder {
 	if v == nil {
 		return Null
@@ -58,7 +58,7 @@ func PInt32(v *int32) Encoder {
 // PInt64 is a pointer version of [Int64].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PInt64].
+// Otherwise, behaves exactly as [Int64].
 func PInt64(v *int64) Encoder {
 	if v == nil {
 		return Null
@@ -69,7 +69,7 @@ func PInt64(v *int64) Encoder {
 // PUInt is a pointer version of [UInt].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PUInt].
+// Otherwise, behaves exactly as [UInt].
 func PUInt(v *uint) Encoder {
 	if v == nil {
 		return Null
@@ -80,7 +80,7 @@ func PUInt(v *uint) Encoder {
 // PUInt8 is a pointer version of [UInt8].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PUInt8].
+// Otherwise, behaves exactly as [UInt8].
 func PUInt8(v *uint8) Encoder {
 	if v == nil {
 		return Null
@@ -91,7 +91,7 @@ func PUInt8(v *uint8) Encoder {
 // PUInt16 is a pointer version of [UInt16].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PUInt16].
+// Otherwise, behaves exactly as [UInt16].
 func PUInt16(v *uint16) Encoder {
 	if v == nil {
 		return Null
@@ -102,7 +102,7 @@ func PUInt16(v *uint16) Encoder {
 // PUInt32 is a pointer version of [UInt32].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PUInt32].
+// Otherwise, behaves exactly as [UInt32].
 func PUInt32(v *uint32) Encoder {
 	if v == nil {
 		return Null
@@ -113,7 +113,7 @@ func PUInt32(v *uint32) Encoder {
 // PUInt64 is a pointer version of [UInt64].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PUInt64].
+// Otherwise, behaves exactly as [UInt64].
 func PUInt64(v *uint64) Encoder {
 	if v == nil {
 		return Null
@@ -124,7 +124,7 @@ func PUInt64(v *uint64) Encoder {
 // PUIntPtr is a pointer version of [UIntPtr].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PUIntPtr].
+// Otherwise, behaves exactly as [UIntPtr].
 func PUIntPtr(v *uintptr) Encoder {
 	if v == nil {
 		return Null
@@ -135,7 +135,7 @@ func PUIntPtr(v *uintptr) Encoder {
 // PFloat32 is a pointer version of [Float32].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PFloat32].
+// Otherwise, behaves exactly as [Float32].
 func PFloat32(v *float32) Encoder {
 	if v == nil {
 		return Null
@@ -146,7 +146,7 @@ func PFloat32(v *float32) Encoder {
 // PFloat64 is a pointer version of [Float64].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PFloat64].
+// Otherwise, behaves exactly as [Float64].
 func PFloat64(v *float64) Encoder {
 	if v == nil {
 		return Null
@@ -157,7 +157,7 @@ func PFloat64(v *float64) Encoder {
 // PString is a pointer version of [String].
 //
 // If the given value is nil, it will be serialized to null.
-// Otherwise, behaves exactly as [PString].
+// Otherwise, behaves exactly as [String].
 func PString(v *string) Encoder {
 	if v == nil {
 		return Null


### PR DESCRIPTION
It seems to me that these links should point to the non-pointer types.

Please take a look.